### PR TITLE
Filter non-running EC2 instances

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,6 +137,10 @@ func getInstancesWithTag(ec2Client *ec2.EC2, key string, value string) ([]*ec2.I
 	err := ec2Client.DescribeInstancesPages(&ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			&ec2.Filter{
+				Name: aws.String("instance-state-name"),
+				Values: []*string{aws.String("running")},
+			},
+			&ec2.Filter{
 				Name:   aws.String(fmt.Sprintf("tag:%s", key)),
 				Values: []*string{aws.String(value)},
 			},


### PR DESCRIPTION
Terminated EC2 instances still appears in the DescribeInstance result with empty PrivateIpAddresses and cause false alerts.
This patch filters out non-running EC2 instances from the check list, and consequently this checker alerts when any living EC2 instances have left the Consul cluster.
